### PR TITLE
fix: signed vs unsigned

### DIFF
--- a/MaxSAT.cc
+++ b/MaxSAT.cc
@@ -351,7 +351,7 @@ void MaxSAT::printBound(int64_t bound)
 
   // print bound only, if its below the hard weight
   // FIXME: possible issue for PB instances when bound is negative; in MaxSAT bound is always positive
-  if( bound < maxsat_formula->getHardWeight() ) printf("o %" PRId64 "\n", bound);
+  if( bound < (int64_t)maxsat_formula->getHardWeight() ) printf("o %" PRId64 "\n", bound);
 }
 
 // Prints the best satisfying model. Assumes that 'model' is not empty.

--- a/encodings/Enc_Adder.cc
+++ b/encodings/Enc_Adder.cc
@@ -107,7 +107,7 @@ void Adder::adderTree (Solver *S, std::vector< std::queue< Lit > > & buckets, ve
   Lit x,y,z;
   Lit u = lit_Undef;
 
-  for ( int i = 0; i < buckets.size(); i++ ) {
+  for ( size_t i = 0; i < buckets.size(); i++ ) {
       if ( buckets[i].size() == 0 )
     continue;
 
@@ -150,7 +150,7 @@ void Adder::adderTree (Solver *S, std::vector< std::queue< Lit > > & buckets, ve
 // xs and ys must have the same size
 
 void Adder::lessThanOrEqual (Solver *S, vec< Lit > & xs, std::vector< uint64_t > & ys) {
-  assert ( xs.size() == ys.size() );
+  assert ( (size_t)xs.size() == ys.size() );
   vec<Lit> clause;
   bool skip;
   for ( int i = 0; i < xs.size(); ++i ) {
@@ -196,7 +196,7 @@ void Adder::lessThanOrEqual (Solver *S, vec< Lit > & xs, std::vector< uint64_t >
 }
 
 void Adder::lessThanOrEqualInc (Solver *S, vec< Lit > & xs, std::vector< uint64_t > & ys, vec<Lit>& assumptions) {
-  assert ( xs.size() == ys.size() );
+  assert ( (size_t)xs.size() == ys.size() );
   vec<Lit> clause;
   bool skip;
   for ( int i = 0; i < xs.size(); ++i ) {
@@ -249,7 +249,7 @@ void Adder::numToBits ( std::vector<uint64_t> & bits, uint64_t n, uint64_t numbe
 
   
   for ( int64_t i = n - 1; i >= 0; --i ) {
-      int64_t tmp = ((int64_t)1) << i;
+      uint64_t tmp = ((uint64_t)1) << i;
       if ( number < tmp ) {
     bits.push_back ( 0 );
     }
@@ -269,7 +269,7 @@ void Adder::encode(Solver *S, vec<Lit> &lits, vec<uint64_t> &coeffs, uint64_t rh
     uint64_t nb = ld64(rhs); // number of bits
     Lit u = lit_Undef;
 
-    for ( int iBit = 0; iBit < nb; ++iBit ) {
+    for ( uint64_t iBit = 0; iBit < nb; ++iBit ) {
         _buckets.push_back ( std::queue<Lit>() );
         _output.push ( u );
         for ( int iVar = 0; iVar < lits.size(); ++iVar ) {
@@ -294,7 +294,7 @@ void Adder::encodeInc(Solver *S, vec<Lit> &lits, vec<uint64_t> &coeffs, uint64_t
     uint64_t nb = ld64(rhs); // number of bits
     Lit u = lit_Undef;
 
-    for ( int iBit = 0; iBit < nb; ++iBit ) {
+    for ( uint64_t iBit = 0; iBit < nb; ++iBit ) {
         _buckets.push_back ( std::queue<Lit>() );
         _output.push ( u );
         for ( int iVar = 0; iVar < lits.size(); ++iVar ) {


### PR DESCRIPTION
When compiling with a recent compiler, and stronger checking, signed
vs unsigned comparison have to be avoided to pass the checks.